### PR TITLE
Specify delay with query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,17 @@ Supported options are:
 Most of the configuration options from the wrapped `capture-website` library are supported using query parameters. 
 For example, to capture a site with a 650x350 viewport, no default background and animations disabled use:
 ```
-curl 'https://capture-website-api.netlify.app/capture?url=http://amazon.com&width=650&height=350&scaleFactor=1&defaultBackground=false&disableAnimations=true' -o screenshot.png
+curl 'https://capture-website-api.netlify.app/capture?url=http://amazon.com&width=650&height=350&scaleFactor=1&defaultBackground=false&disableAnimations=true&wait_before_screenshot_ms=300' -o screenshot.png
 ```
 
 See https://github.com/sindresorhus/capture-website for a full list of options.
+
+### Capture Delay
+
+You may require to wait for async requests or animations to finish before capturing the screenshot. There are two ways of doing this, both specified in the query parameters:
+
+1. `wait_before_screenshot_ms` (in ms, defaults to `300`) will wait before capturing a screenshot.
+2. For standalone: `capture-website` library's [`delay`](https://github.com/sindresorhus/capture-website#delay) (in seconds)
 
 ## Use plain Puppeteer 
 

--- a/serverless/src/helpers.js
+++ b/serverless/src/helpers.js
@@ -77,8 +77,8 @@ async function takePlainPuppeteerScreenshot(url, options) {
     const browser = await puppeteer.launch(options.launchOptions);
     const page = await browser.newPage();
     await page.goto(url);
-    await new Promise(r => setTimeout(r, 300));
     await setViewport(page, options);
+    await new Promise(r => setTimeout(r, 300));
     const buffer = await page.screenshot();
     await browser.close();
     return buffer;

--- a/serverless/src/helpers.js
+++ b/serverless/src/helpers.js
@@ -74,11 +74,12 @@ async function tryWithPuppeteer(url, options) {
 
 async function takePlainPuppeteerScreenshot(url, options) {
     options.encoding = 'binary';
+    options.wait_before_screenshot_ms = options.wait_before_screenshot_ms || 300;
     const browser = await puppeteer.launch(options.launchOptions);
     const page = await browser.newPage();
     await page.goto(url);
     await setViewport(page, options);
-    await new Promise(r => setTimeout(r, 300));
+    await new Promise(r => setTimeout(r, options.wait_before_screenshot_ms));
     const buffer = await page.screenshot();
     await browser.close();
     return buffer;

--- a/standalone/src/helpers.js
+++ b/standalone/src/helpers.js
@@ -114,8 +114,8 @@ async function takePlainPuppeteerScreenshot(url, options) {
     const browser = await puppeteer.launch(options.launchOptions);
     const page = await browser.newPage();
     await page.goto(url);
-    await new Promise(r => setTimeout(r, 3000));
     await setViewport(page, options);
+    await new Promise(r => setTimeout(r, 3000));
     const buffer = await page.screenshot();
     await browser.close();
     return buffer;

--- a/standalone/src/helpers.js
+++ b/standalone/src/helpers.js
@@ -111,11 +111,12 @@ async function tryWithPuppeteer(url, options) {
 
 async function takePlainPuppeteerScreenshot(url, options) {
     options.encoding = 'binary';
+    options.wait_before_screenshot_ms = options.wait_before_screenshot_ms || 300;
     const browser = await puppeteer.launch(options.launchOptions);
     const page = await browser.newPage();
     await page.goto(url);
     await setViewport(page, options);
-    await new Promise(r => setTimeout(r, 3000));
+    await new Promise(r => setTimeout(r, options.wait_before_screenshot_ms));
     const buffer = await page.screenshot();
     await browser.close();
     return buffer;


### PR DESCRIPTION
Specifying wait time `wait_before_screenshot_ms=300` (in ms) when capturing screenshots after the page is loaded.

```
https://example.vercel.app/api/capture?wait_before_screenshot_ms=300&url=https://alerts.in.ua/?minimal&disableInteractiveMap
```

The default delay is 300ms.